### PR TITLE
separate route logic

### DIFF
--- a/src/api/v1/posts.js
+++ b/src/api/v1/posts.js
@@ -1,55 +1,19 @@
 const express = require("express");
-const { getSource } = require("../../posts/source");
+const {
+  getAllPosts,
+  createPost,
+  getPostByName,
+  updatePost,
+  deletePost,
+} = require("../../posts/service");
 
 const postRouter = express.Router();
 const postRoute = "/posts";
-const BLOG_ROUTE = process.env.BLOG_ROUTE || "/blog";
 
-postRouter.get("/", async (req, res) => {
-  try {
-    const { readPosts } = getSource();
-    const posts = await readPosts();
-    res.status(200).json(posts);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-});
-
-postRouter.post("/", async (req, res) => {
-  try {
-    const { writePost } = getSource();
-    const { markdown, metadata } = req.body;
-    const slug = await writePost({ markdown, metadata });
-
-    res.status(201).json({
-      message: "Post created successfully",
-      redirectUrl: `${BLOG_ROUTE}/${slug}`,
-    });
-  } catch (error) {
-    console.error(error);
-    if (error.message === "Missing slug in metadata") {
-      return res.status(400).json({ error: error.message });
-    }
-    res.status(500).json({ error: "Error saving files" });
-  }
-});
-
-postRouter.get("/:postName", async (req, res) => {
-  try {
-    const { readPost } = getSource();
-    const postData = await readPost(req.params.postName);
-    res.status(200).json(postData);
-  } catch (error) {
-    res.status(error.status || 500).json({ error: error.message });
-  }
-});
-
-postRouter.put("/:postName", async (req, res) => {
-  res.json({ message: "Post route is working ✅" });
-});
-
-postRouter.delete("/:postName", async (req, res) => {
-  res.json({ message: "Post route is working ✅" });
-});
+postRouter.get("/", getAllPosts);
+postRouter.post("/", createPost);
+postRouter.get("/:postName", getPostByName);
+postRouter.put("/:postName", updatePost);
+postRouter.delete("/:postName", deletePost);
 
 module.exports = { postRouter, postRoute };

--- a/src/posts/config.js
+++ b/src/posts/config.js
@@ -1,6 +1,7 @@
 require("dotenv").config();
 
 module.exports = {
+  blog_route: process.env.BLOG_ROUTE || "/blog",
   source: process.env.POST_SOURCE || "local",
   github: {
     repo: process.env.GITHUB_REPO,

--- a/src/posts/service.js
+++ b/src/posts/service.js
@@ -1,0 +1,59 @@
+const config = require("./config");
+const { getSource } = require("./source");
+
+const blog_route = config.blog_route;
+
+async function getAllPosts(req, res) {
+  try {
+    const { readPosts } = getSource();
+    const posts = await readPosts();
+    res.status(200).json(posts);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+}
+
+async function createPost(req, res) {
+  try {
+    const { writePost } = getSource();
+    const { markdown, metadata } = req.body;
+    const slug = await writePost({ markdown, metadata });
+
+    res.status(201).json({
+      message: "Post created successfully",
+      redirectUrl: `${blog_route}/${slug}`,
+    });
+  } catch (error) {
+    console.error(error);
+    if (error.message === "Missing slug in metadata") {
+      return res.status(400).json({ error: error.message });
+    }
+    res.status(500).json({ error: "Error saving files" });
+  }
+}
+
+async function getPostByName(req, res) {
+  try {
+    const { readPost } = getSource();
+    const postData = await readPost(req.params.postName);
+    res.status(200).json(postData);
+  } catch (error) {
+    res.status(error.status || 500).json({ error: error.message });
+  }
+}
+
+async function updatePost(req, res) {
+  res.json({ message: "Post route is working ✅" });
+}
+
+async function deletePost(req, res) {
+  res.json({ message: "Post route is working ✅" });
+}
+
+module.exports = {
+  getAllPosts,
+  createPost,
+  getPostByName,
+  updatePost,
+  deletePost,
+};


### PR DESCRIPTION
**refactor: separate post route handlers into dedicated service module**

* Extracted all route handler functions (`getAllPosts`, `createPost`, etc.) from `api/v1/posts.js` into a new `posts/service.js` module.
* Simplified `api/v1/posts.js` to only define routes and delegate logic to service functions.
* Added `blog_route` config back to `posts/config.js` to centralize configuration.
* Improves code organization and separation of concerns, facilitating maintainability and testing.
